### PR TITLE
Return Result from EmailAddress::new()

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ type, so you can stop stringly-typing your email addresses.
 use emailaddress::EmailAddress;
 
 fn main() {
-    let email = EmailAddress::new("someone@example.com");
+    let email = EmailAddress::new("someone@example.com").unwrap();
     assert_eq!(email.local, "someone".to_string()); 
     assert_eq!(email.domain, "example.com".to_string());
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -27,8 +27,8 @@ pub struct EmailAddress {
 }
 
 impl EmailAddress {
-    pub fn new(string: &str) -> EmailAddress {
-        parse(string).unwrap()
+    pub fn new(string: &str) -> Result<EmailAddress, AddrError> {
+        parse(string)
     }
 }
 


### PR DESCRIPTION
When instantiating an EmailAddress, using new() is the most natural API; it
also allows the user not to care about which parsing algorithm is used under
the covers, providing less friction for the user. However, due to the use
of unwrap() inside new(), invalid email addresses will panic. Instead,
propagate out the Result type from the parser to new()'s caller.